### PR TITLE
Use correct and valid KEYWORD_TOKENTYPEs in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,9 +1,9 @@
 IMUGY85	KEYWORD1
 init	KEYWORD2
-update	KEYWORD3
-getRoll	KEYWORD4
-getPitch	KEYWORD5
-getYaw	KEYWORD6
-getRawYaw	KEYWORD7
-getAcceleration	KEYWORD8
-getGyro	KEYWORD9
+update	KEYWORD2
+getRoll	KEYWORD2
+getPitch	KEYWORD2
+getYaw	KEYWORD2
+getRawYaw	KEYWORD2
+getAcceleration	KEYWORD2
+getGyro	KEYWORD2


### PR DESCRIPTION
Use of an invalid KEYWORD_TOKENTYPE value in keywords.txt causes the keyword to be highlighted by the default editor.function.style theme setting (as used by KEYWORD2, KEYWORD3) in Arduino IDE 1.6.5 and newer. On Arduino IDE 1.6.4 and older, the undocumented KEYWORD4 causes the keyword to use the theme style used for operators, KEYWORD5 causes the keyword to use the theme style for hyperlinks, KEYWORD6 uses editor.invalid.style, KEYWORD7-9 causes the IDE to glitch out.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keyword_tokentype